### PR TITLE
Fast forward git repository support

### DIFF
--- a/loaders/loaders_repository_test.go
+++ b/loaders/loaders_repository_test.go
@@ -82,6 +82,6 @@ func (s *RepositoryTestSuite) TestRepositoryLoadGitNotExist() {
 	ld := NewRepositoryLoader(s.cacheDir)
 	repo, err := ld.Load("https://github.com/octocat/Foo-Bar.git")
 	s.Error(err)
-	s.Equal("unclonable repository: authentication required", err.Error())
+	s.Equal("unable to clone repository: authentication required", err.Error())
 	s.Nil(repo)
 }


### PR DESCRIPTION
[Go-git](https://github.com/src-d/go-git) library does not suport fast forward update, let's get around this limitation by removing git cache directory, and cloning it again :)