### PR TITLE
misc: stop the ascent on a swallowed walk error

### DIFF
--- a/internal/filepath/backwalk/backwalk.go
+++ b/internal/filepath/backwalk/backwalk.go
@@ -19,22 +19,26 @@ func walkDir(path string, dir os.DirEntry, walkDirFunc fs.WalkDirFunc) error {
 
 	pathAbs, err := filepath.Abs(path)
 	if err != nil {
-		// Second call, to report Abs error
-		err = walkDirFunc(path, dir, err)
-		if err != nil {
+		// Report the error; if the callback does not abort, stop ascending
+		// rather than continuing with an invalid path.
+		if err := walkDirFunc(path, dir, err); err != nil {
 			return err
 		}
+
+		return nil
 	}
 
 	// Get parent dir
 	parent := filepath.Join(path, "..")
 	parentAbs, err := filepath.Abs(parent)
 	if err != nil {
-		// Second call, to report parent Abs error
-		err = walkDirFunc(parent, dir, err)
-		if err != nil {
+		// Report the error; if the callback does not abort, stop ascending
+		// rather than continuing with an invalid parent path.
+		if err := walkDirFunc(parent, dir, err); err != nil {
 			return err
 		}
+
+		return nil
 	}
 
 	// If absolute parent path equals to absolute path,
@@ -45,11 +49,13 @@ func walkDir(path string, dir os.DirEntry, walkDirFunc fs.WalkDirFunc) error {
 
 	info, err := os.Lstat(parent)
 	if err != nil {
-		// Second call, to report Stat error.
-		err = walkDirFunc(parent, dir, err)
-		if err != nil {
+		// Report the error; if the callback does not abort, stop here rather
+		// than recursing with a nil DirEntry (which would panic on IsDir()).
+		if err := walkDirFunc(parent, dir, err); err != nil {
 			return err
 		}
+
+		return nil
 	}
 
 	if err := walkDir(parent, fs.FileInfoToDirEntry(info), walkDirFunc); err != nil {


### PR DESCRIPTION
  ## Problem

  During the recursive ascent, when `filepath.Abs` or `os.Lstat` on an ancestor
  fails, `backwalk` reports the error to the callback and then *continues* if the
  callback returns `nil` (a legitimate `WalkDirFunc` choice). For the `Abs` cases
  it walks on with an empty path; for the `Lstat` case it recurses with
  `fs.FileInfoToDirEntry(nil)` and panics on `IsDir()`.

  This diverges from `filepath.WalkDir`, which does not descend after an error.

  ## Change
  
  Once the callback has been handed the error and declines to abort, return
  instead of continuing with invalid state.

  ## Note

  Latent today: both current callers (`project.LoadFrom` and the legacy
  `from.go`) always return the error, so the bad path is never taken. This is
  defensive hardening that aligns `backwalk` with the stdlib semantics for the
  next caller. Triggering the panic needs an un-`lstat`-able ancestor, which
  isn't portably reproducible in a test, so the existing happy-path
  `BackwalkSuite` is unchanged.