### PR TITLE
misc: write files atomically to prevent corruption on failure

### DIFF
--- a/internal/sync/syncer.go
+++ b/internal/sync/syncer.go
@@ -211,27 +211,69 @@ func (syncer *Syncer) syncNode(node *node) error {
 
 	// Files are not equals or destination does not exist
 	if !equal {
-		// Destination file mode
-		var dstMode os.FileMode = 0o666
-		if node.Src.IsExecutable {
-			dstMode = 0o777
-		}
-
-		// Create or truncate destination file
-		dstFile, err := os.OpenFile(node.Dst.Path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, dstMode)
+		// Write to a temporary file in the destination directory, then rename
+		// it into place. Renaming is atomic, so an interrupted copy or a flush
+		// error leaves any existing destination untouched instead of truncating
+		// it in place.
+		tmpFile, err := os.CreateTemp(filepath.Dir(node.Dst.Path), ".manala-sync-*")
 		if err != nil {
 			return serror.New("file system error").
 				With("file", node.Dst.Path).
 				WithErr(std.From(err))
 		}
 
-		defer dstFile.Close()
+		tmpPath := tmpFile.Name()
 
-		// Copy from source to destination
-		_, err = io.Copy(dstFile, srcReader)
-		if err != nil {
+		// Remove the temporary file unless it is successfully renamed into place.
+		committed := false
+		defer func() {
+			if !committed {
+				_ = tmpFile.Close()
+				_ = os.Remove(tmpPath)
+			}
+		}()
+
+		// Copy from source to the temporary file
+		if _, err := io.Copy(tmpFile, srcReader); err != nil {
 			return err
 		}
+
+		// Flush and close, surfacing a late write error (e.g. a full disk
+		// reported only at close) instead of swallowing it.
+		if err := tmpFile.Sync(); err != nil {
+			return serror.New("file system error").
+				With("file", node.Dst.Path).
+				WithErr(std.From(err))
+		}
+		if err := tmpFile.Close(); err != nil {
+			return serror.New("file system error").
+				With("file", node.Dst.Path).
+				WithErr(std.From(err))
+		}
+
+		// Destination file mode: preserve an existing file's permissions
+		// (matching the previous in-place truncate), use a standard mode for a
+		// new file.
+		dstMode := node.Dst.Mode
+		if !node.Dst.IsExist {
+			dstMode = 0o644
+			if node.Src.IsExecutable {
+				dstMode = 0o755
+			}
+		}
+		if err := os.Chmod(tmpPath, dstMode); err != nil {
+			return serror.New("file system error").
+				With("file", node.Dst.Path).
+				WithErr(std.From(err))
+		}
+
+		// Atomically replace the destination
+		if err := os.Rename(tmpPath, node.Dst.Path); err != nil {
+			return serror.New("file system error").
+				With("file", node.Dst.Path).
+				WithErr(std.From(err))
+		}
+		committed = true
 
 		// Log
 		syncer.log.Info("file synced",


### PR DESCRIPTION
  ## Problem

  `syncNode` opens the destination with `O_RDWR|O_CREATE|O_TRUNC` and then
  `io.Copy`s the new content into it. `O_TRUNC` empties the existing file
  *before* a single byte is written, so an interrupted copy (a read error on the
  source, or a write error such as `ENOSPC`) leaves the destination truncated or
  half-written — the previous, valid file is gone.

  The only flush of the written file was also a deferred `dstFile.Close()` whose
  error was discarded, so a failure surfaced only at close (full disk, NFS
  close-to-open) was reported as a successful sync.

  ## Change
  
  Write to a temporary file in the destination directory, then `os.Rename` it
  into place. Rename is atomic, so on any failure the existing destination is
  left untouched. `Sync()` and `Close()` errors are now surfaced instead of
  swallowed.

  ## Notes / behaviour changes

  - **Permissions**: an existing file keeps its current mode (same as the old
    in-place truncate, which ignored the create mode on an existing file). A new
    file is created `0644` / `0755` (executable); the old code passed `0666` /
    `0777` to `OpenFile` and relied on the umask, which under the usual `022`
    yields the same `0644` / `0755`.
  - **Atomic replace needs a writable destination *directory*** (to create the
    temp file and rename it), whereas in-place truncate only needed the *file* to
    be writable. A read-only directory holding writable files would now fail.
    In practice the destination is the user's project dir, which is writable.
  - The destination is replaced (new inode) rather than rewritten in place.

  ## Tests

  `TestSync` and `TestSyncExecutable` still pass (content + executable-bit                                                                                                                                                                                                                    
  behaviour unchanged). The failure path isn't reachable through the public
  `Sync` API (no injection seam), so it isn't unit-tested — the atomicity is by
  construction (temp + rename).
