### PR TITLE
misc: bound anchor expansion to prevent billion-laughs DoS

### DIFF
--- a/internal/yaml/parser/parse.go
+++ b/internal/yaml/parser/parse.go
@@ -52,7 +52,7 @@ func Parse(data []byte) (*ast.MappingNode, error) {
 	}
 
 	// Resolve
-	if err := resolve(node, w.anchors, map[string]bool{}); err != nil {
+	if err := resolve(node, w.anchors, map[string]bool{}, new(int)); err != nil {
 		return nil, err
 	}
 

--- a/internal/yaml/parser/parse_test.go
+++ b/internal/yaml/parser/parse_test.go
@@ -207,6 +207,22 @@ func (s *ParseSuite) TestAnchorsCycle() {
 	})
 }
 
+func (s *ParseSuite) TestAnchorsExpansionLimit() {
+	// Exponential alias fan-out (a "billion laughs" bomb) must be rejected
+	// during resolution rather than exhausting memory materializing the
+	// expanded value tree.
+	_, err := yamlparser.Parse([]byte(heredoc.Doc(`
+		a: &a [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+		b: &b [*a, *a, *a, *a, *a, *a, *a, *a, *a, *a]
+		c: &c [*b, *b, *b, *b, *b, *b, *b, *b, *b, *b]
+		d: &d [*c, *c, *c, *c, *c, *c, *c, *c, *c, *c]
+		e: &e [*d, *d, *d, *d, *d, *d, *d, *d, *d, *d]
+		bomb: *e
+	`)))
+
+	s.Require().ErrorContains(err, "yaml anchor expansion limit exceeded")
+}
+
 func (s *ParseSuite) TestTags() {
 	node, err := yamlparser.Parse([]byte(heredoc.Doc(`
 		foo: !!str bar

--- a/internal/yaml/parser/resolve.go
+++ b/internal/yaml/parser/resolve.go
@@ -9,9 +9,16 @@ import (
 	"github.com/goccy/go-yaml/ast"
 )
 
+// maxResolveNodes bounds the number of nodes visited while expanding yaml
+// anchors. It aborts pathological exponential alias fan-out (the "billion
+// laughs" attack) during resolution — before the shared anchor DAG would be
+// materialized into an exponential value tree by NodeToValue.
+const maxResolveNodes = 100_000
+
 // resolve replaces aliases with their anchor values and deduplicates mapping keys.
 // visiting tracks anchor names currently being resolved to detect cycles.
-func resolve(node ast.Node, anchors map[string]ast.Node, visiting map[string]bool) error {
+// count tracks the number of resolved nodes to bound anchor expansion.
+func resolve(node ast.Node, anchors map[string]ast.Node, visiting map[string]bool, count *int) error {
 	switch n := node.(type) {
 	case *ast.MappingNode:
 		deduplicatedValues := make([]*ast.MappingValueNode, 0)
@@ -72,7 +79,7 @@ func resolve(node ast.Node, anchors map[string]ast.Node, visiting map[string]boo
 				deduplicatedValues = append(deduplicatedValues, mv)
 
 				// Resolve
-				if err := resolveValue(&mv.Value, anchors, visiting); err != nil {
+				if err := resolveValue(&mv.Value, anchors, visiting, count); err != nil {
 					return err
 				}
 			}
@@ -82,7 +89,7 @@ func resolve(node ast.Node, anchors map[string]ast.Node, visiting map[string]boo
 
 	case *ast.SequenceNode:
 		for idx := range n.Values {
-			if err := resolveValue(&n.Values[idx], anchors, visiting); err != nil {
+			if err := resolveValue(&n.Values[idx], anchors, visiting, count); err != nil {
 				return err
 			}
 		}
@@ -120,14 +127,24 @@ func resolveMergeAlias(alias *ast.AliasNode, anchors map[string]ast.Node, visiti
 	return mn, nil
 }
 
-func resolveValue(node *ast.Node, anchors map[string]ast.Node, visiting map[string]bool) error {
+func resolveValue(node *ast.Node, anchors map[string]ast.Node, visiting map[string]bool, count *int) error {
+	// Bound anchor expansion: each resolved node counts, so exponential alias
+	// fan-out trips this well before it can be materialized into values.
+	*count++
+	if *count > maxResolveNodes {
+		return yamlerrors.New(
+			errors.New("yaml anchor expansion limit exceeded"),
+			(*node).GetToken(),
+		)
+	}
+
 	switch n := (*node).(type) {
 	case *ast.TagNode:
 		*node = n.Value
-		return resolveValue(node, anchors, visiting)
+		return resolveValue(node, anchors, visiting, count)
 	case *ast.MappingKeyNode:
 		*node = n.Value
-		return resolveValue(node, anchors, visiting)
+		return resolveValue(node, anchors, visiting, count)
 	case *ast.AliasNode:
 		name := n.Value.GetToken().Value
 
@@ -148,7 +165,7 @@ func resolveValue(node *ast.Node, anchors map[string]ast.Node, visiting map[stri
 
 		visiting[name] = true
 		*node = anchor
-		err := resolveValue(node, anchors, visiting)
+		err := resolveValue(node, anchors, visiting, count)
 		delete(visiting, name)
 		return err
 	case *ast.AnchorNode:
@@ -163,10 +180,10 @@ func resolveValue(node *ast.Node, anchors map[string]ast.Node, visiting map[stri
 
 		visiting[name] = true
 		*node = n.Value
-		err := resolveValue(node, anchors, visiting)
+		err := resolveValue(node, anchors, visiting, count)
 		delete(visiting, name)
 		return err
 	default:
-		return resolve(*node, anchors, visiting)
+		return resolve(*node, anchors, visiting, count)
 	}
 }


### PR DESCRIPTION
## Problem

  A manifest with exponentially nested anchor aliases (a "billion laughs" bomb)
  expands into a shared AST DAG that `NodeToValue` then materializes as an
  exponential value tree, exhausting memory from a tiny (~400 byte) input. The
  resolver only guarded against cycles (`visiting`), not non-cyclic fan-out.

  ```yaml
  a: &a [0,1,2,3,4,5,6,7,8,9]
  b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a,*a]
  # ... a few more levels ...
  bomb: *f
  ```

  ## Change

  Thread a node counter through anchor resolution and abort past
  `maxResolveNodes` (100k). Because the resolver re-walks the shared anchor on
  every alias, the counter trips during resolution — cheaply, before any
  materialization. Legitimate manifests are orders of magnitude below the limit.
