### PR TITLE
misc: validation no external refs

### DIFF
--- a/internal/validation/validator.go
+++ b/internal/validation/validator.go
@@ -18,6 +18,11 @@ type Validator struct {
 func NewValidator(schema map[string]any) (*Validator, error) {
 	compiler := jsonschema.NewCompiler()
 
+	// Block external $ref resolution. Manala schemas are added in memory, so no
+	// URL is ever legitimately fetched; an empty loader rejects every scheme,
+	// closing the file:// local-file read/existence oracle in @schema refs.
+	compiler.UseLoader(jsonschema.SchemeURLLoader{})
+
 	if err := compiler.AddResource("urn:manala", schema); err != nil {
 		return nil, err
 	}

--- a/internal/validation/validator_test.go
+++ b/internal/validation/validator_test.go
@@ -16,6 +16,18 @@ func TestValidatorSuite(t *testing.T) {
 	suite.Run(t, new(ValidatorLocatorSuite))
 }
 
+func (s *ValidatorLocatorSuite) TestNewValidatorRejectsExternalRef() {
+	// An untrusted schema must not read local files via a $ref to an external
+	// URL — the ref is rejected at compile time, not fetched.
+	_, err := validation.NewValidator(map[string]any{
+		"$ref": "file:///etc/passwd",
+	})
+
+	// The scheme is rejected before any file access (no read/existence oracle):
+	// the default loader would instead open the file and fail parsing it.
+	s.Require().ErrorContains(err, "no URLLoader registered")
+}
+
 func (s *ValidatorLocatorSuite) TestValidateViolations() {
 	tests := []struct {
 		test     string


### PR DESCRIPTION
 ## Problem

  A recipe schema is untrusted, so a `@schema {"$ref": "file:///etc/passwd"}`
  annotation made the json-schema compiler open local files through the default
  loader — a file read/existence oracle. (Confirmed: without the fix the compiler
  opens the file and fails parsing it as JSON.)

  ## Change

  Register an empty `SchemeURLLoader`, which rejects every URL scheme. Manala
  schemas are added in memory (`AddResource`), so no URL is ever legitimately
  fetched; an external `$ref` now errors at compile time instead of touching the
  filesystem.
